### PR TITLE
Archive now displays 1 link for each month/year that posts exist in

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -74,7 +74,7 @@ meta_generator: true
 ## Hexo uses Moment.js to parse and display date
 ## You can customize the date format as defined in
 ## http://momentjs.com/docs/#/displaying/format/
-date_format: YYYY-MM-DD
+date_format: MMMM YYYY
 time_format: HH:mm:ss
 ## Use post's date for updated date unless set in front-matter
 use_date_for_updated: false

--- a/themes/axon/layout/_partial/sidebar.ejs
+++ b/themes/axon/layout/_partial/sidebar.ejs
@@ -21,11 +21,21 @@
         <h4>Archives</h4>
         <hr>
         <ul class="list-styled">
-            <li><a href="#">March 2014</a></li>
-            <li><a href="#">February 2014</a></li>
-            <li><a href="#">January 2014</a></li>
-            <li><a href="#">December 2013</a></li>
-            <li><a href="#">November 2013</a></li>
+            <% let archiveDates = [] %>
+            <% let archiveLinks = [] %>
+            <% posts.forEach(function(item) { %>
+                <% if (item.date) { %>
+                    <% archiveDates.push(item.date.format(config.date_format)); %>
+                    <% archiveLinks.push(item.path); %>
+                <% } %>
+            <% }); %>
+            <% console.log(archiveDates) %>
+            <% console.log(archiveLinks) %>
+            <% for (let i = 0; i < archiveDates.length; i++) { %>
+                <% if (archiveDates[i] !== archiveDates[i-1]) { %>
+                    <li><a href="<%- config.root %><%- archiveLinks[i] %>"><%- archiveDates[i] %></a></li>
+                <% } %>
+            <% } %>
         </ul>
     </div>
     <div class="sidebar-module">
@@ -33,9 +43,9 @@
         <h4>Elsewhere</h4>
         <hr>
         <ul class="list-styled">
-            <li><a href="#">Github</a></li>
-            <li><a href="#">Twitter</a></li>
-            <li><a href="#">Facebook</a></li>
+            <li><a href="https://github.com/BranonConor">Github</a></li>
+            <li><a href="https://www.linkedin.com/in/branonconor/">LinkedIn</a></li>
+            <li><a href="https://www.instagram.com/bran.js/">Instagram</a></li>
         </ul>
     </div> 
 </div>


### PR DESCRIPTION
- Archive now programmed to display the month/year for each month/year in which posts exist (regardless of how many)

Engineering: 
- it takes all posts and pushes their dates into one array, and pushes their links into another array
- It then iterates over the array of dates, and checks if the current index value is the same as its previous index (checking for duplicate dates)
- for each unique value it finds in the array, it will render that date as a list element using EJS, duplicates will be ignored

Considerations:
- Consider big-O for this logic , no nested loops which is good